### PR TITLE
Dev6

### DIFF
--- a/app/tag-data.json
+++ b/app/tag-data.json
@@ -1,1 +1,1 @@
-{"markdown":1,"code":1,"features":1,"next-js":7,"math":1,"ols":1,"github":1,"guide":5,"tailwind":3,"hello":1,"holiday":1,"canada":1,"images":1,"feature":2,"ua-sds":1,"howto":1,"writings":1,"book":1,"reflection":1,"multi-author":1}
+{"next-js":7,"ua-sds":1,"howto":1,"tailwind":3,"guide":5,"feature":2,"multi-author":1,"hello":1,"math":1,"ols":1,"github":1,"writings":1,"book":1,"reflection":1,"holiday":1,"canada":1,"images":1,"markdown":1,"code":1,"features":1}

--- a/app/tag-data.json
+++ b/app/tag-data.json
@@ -1,1 +1,1 @@
-{"markdown":1,"code":1,"features":1,"next-js":7,"math":1,"ols":1,"github":1,"guide":5,"tailwind":3,"holiday":1,"canada":1,"images":1,"feature":2,"ua-sds":1,"howto":1,"writings":1,"book":1,"reflection":1,"multi-author":1}
+{"markdown":1,"code":1,"features":1,"next-js":7,"math":1,"ols":1,"github":1,"guide":5,"tailwind":3,"hello":1,"holiday":1,"canada":1,"images":1,"feature":2,"ua-sds":1,"howto":1,"writings":1,"book":1,"reflection":1,"multi-author":1}

--- a/data/blog/site-dev-and-maintenance.mdx
+++ b/data/blog/site-dev-and-maintenance.mdx
@@ -156,6 +156,10 @@ Be sure to update the `data/authors/default.mdx` page with all of your informati
 You can customize your CV by modifying the `data/resume/default.mdx` file, using the template as guidance for formatting (it's just pretty simple markdown syntax). Keep in mind that the header levels correspond to indents in a table-of-contents style sidebar on the CV page.
 
 ### [Deploying Git Repositories with Vercel](https://vercel.com/docs/deployments/git)
+
+> [!IMPORTANT]
+> **UPDATE AS OF DECEMBER 2024**: Vercel now uses Node.js version `22.X` as its default for new projects when running `yarn build`, meaning that **the first time you deploy it will fail! This is fine, let it fail!**  Once the build has failed, navigate to the `Project` page on Vercel and click on the `Settings` tab (above your project's name). Scroll down to "**Node.js Version**" and from the pulldown menu select `20.X` (the default will have `22.X`). Click the **Save** button below, then go back to the `Project` tab. Click `Redeploy`, don't modify any options on the pop up and redeploy the page. This time it should build successfully. See this link if you get stuck:  [https://vercel.com/docs/functions/runtimes/node-js/node-js-versions](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions)
+
 Time to start deploying!
 
 ## More Advanced Stuff

--- a/layouts/ResumeLayout.tsx
+++ b/layouts/ResumeLayout.tsx
@@ -22,7 +22,7 @@ function ResumeLayout({ children, toc }: LayoutProps) {
         <div className="resume opacity-90">
           <header className="space-y-2 pb-8 pt-6 md:space-y-5">
             <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
-              Cirriculum Vitae
+              Curriculum Vitae
             </h1>
             <p className="text-base text-gray-500 dark:text-gray-400 md:text-lg md:leading-7">
               An overview of my education, career, skills, and publications.

--- a/scripts/rss.mjs
+++ b/scripts/rss.mjs
@@ -3,7 +3,7 @@ import path from 'path'
 import { slug } from 'github-slugger'
 import { escape } from 'pliny/utils/htmlEscaper.js'
 import siteMetadata from '../data/siteMetadata.js'
-import tagData from '../app/tag-data.json' assert { type: 'json' }
+import tagData from '../app/tag-data.json' with { type: 'json' }
 import { allBlogs } from '../.contentlayer/generated/index.mjs'
 import { sortPosts } from 'pliny/utils/contentlayer.js'
 

--- a/scripts/rss.mjs
+++ b/scripts/rss.mjs
@@ -3,7 +3,7 @@ import path from 'path'
 import { slug } from 'github-slugger'
 import { escape } from 'pliny/utils/htmlEscaper.js'
 import siteMetadata from '../data/siteMetadata.js'
-import tagData from '../app/tag-data.json' with { type: 'json' }
+import tagData from '../app/tag-data.json' assert { type: 'json' }
 import { allBlogs } from '../.contentlayer/generated/index.mjs'
 import { sortPosts } from 'pliny/utils/contentlayer.js'
 


### PR DESCRIPTION
**UPDATES**

- Corrected spelling of Curriculum on CV page
- Updated instructions for Vercel deployment due to issue with new projects defaulting to Node.js building using `22.X`, needs to be changed to `20.X` manually after initial failed build and a manual redeployment be run in order to successfully build. Note once the project setting has been changed to `20.X` it shouldn't need to be updated again.
- There was a correction that was reverted for "assert" in rss.mjs, this will show up in the commit history but was not necessary so it was reverted to original.